### PR TITLE
Fix several Exit End Portal related bugs

### DIFF
--- a/src/main/java/rlmixins/config/FirstAidConfig.java
+++ b/src/main/java/rlmixins/config/FirstAidConfig.java
@@ -1,0 +1,53 @@
+package rlmixins.config;
+
+import fermiumbooter.annotations.MixinConfig;
+import net.minecraftforge.common.config.Config;
+import rlmixins.RLMixins;
+import rlmixins.util.ModLoadedUtil;
+
+@MixinConfig(name = RLMixins.MODID)
+public class FirstAidConfig {
+
+	@Config.Comment("Properly preserve health when using the Exit End Portal")
+	@Config.Name("End Exit Health Patch (FirstAid)")
+	@Config.RequiresMcRestart
+	@MixinConfig.MixinToggle(
+			earlyMixin = "mixins.rlmixins.early.firstaid.endexithealth.json",
+			lateMixin = "mixins.rlmixins.late.firstaid.endexithealth.json",
+			defaultValue = false)
+	@MixinConfig.CompatHandling(
+			modid = ModLoadedUtil.FirstAid_MOID,
+			desired = true,
+			reason = "Requires mod to properly function"
+	)
+	public boolean endExitHealthPatch = false;
+
+	@Config.Comment("Compatibility patch for the End Exit Health Patch when PotionCore is present")
+	@Config.Name("End Exit Health Patch with PotionCore Compat (FirstAid/PotionCore)")
+	@Config.RequiresMcRestart
+	@MixinConfig.MixinToggle(lateMixin = "mixins.rlmixins.late.firstaid.potioncore.endexithealth.json", defaultValue = false)
+	@MixinConfig.CompatHandlingContainer({
+			@MixinConfig.CompatHandling(
+					modid = ModLoadedUtil.FirstAid_MOID,
+					desired = true,
+					reason = "Requires mod to properly function"
+			),
+			@MixinConfig.CompatHandling(
+					modid = ModLoadedUtil.PotionCore_MODID,
+					desired = true,
+					reason = "Requires mod to properly function"
+			)
+	})
+	public boolean endExitHealthPatchPotionCoreCompat = false;
+
+	@Config.Comment("Properly preserve health when logging in")
+	@Config.Name("Login Health Patch (FirstAid)")
+	@Config.RequiresMcRestart
+	@MixinConfig.MixinToggle(lateMixin = "mixins.rlmixins.late.firstaid.login.json", defaultValue = false)
+	@MixinConfig.CompatHandling(
+			modid = ModLoadedUtil.FirstAid_MOID,
+			desired = true,
+			reason = "Requires mod to properly function"
+	)
+	public boolean loginHealthPatch = false;
+}

--- a/src/main/java/rlmixins/config/PotionCoreConfig.java
+++ b/src/main/java/rlmixins/config/PotionCoreConfig.java
@@ -39,4 +39,9 @@ public class PotionCoreConfig {
 	@Config.Name("Cure Applies On Attack")
 	@Config.RequiresMcRestart
 	public boolean cureAppliesOnAttack = false;
+
+	@Config.Comment("Makes health persist when using the Exit End Portal\nThere is a similar issue with ScalingHealth)")
+	@Config.Name("Persistent Health Fix")
+	@Config.RequiresMcRestart
+	public boolean persistentHealthFix = false;
 }

--- a/src/main/java/rlmixins/config/ScalingHealthConfig.java
+++ b/src/main/java/rlmixins/config/ScalingHealthConfig.java
@@ -47,6 +47,19 @@ public class ScalingHealthConfig {
 	)
 	public boolean enableAdditionalBlightPotionEffects = false;
 
+	@Config.Comment("Makes the player keep their health when using the Exit End portal instead of restoring it to" +
+			"full\nNote: this also prevents restoring the Max Health, \"Keep Attributes on End Exit\" should be used" +
+			"in conjunction with this to keep the Max Health as well")
+	@Config.Name("Keep Health on End Exit (ScalingHealth)")
+	@Config.RequiresMcRestart
+	@MixinConfig.MixinToggle(lateMixin = "mixins.rlmixins.late.scalinghealth.endexithealth.json", defaultValue = false)
+	@MixinConfig.CompatHandling(
+			modid = ModLoadedUtil.ScalingHealth_MODID,
+			desired = true,
+			reason = "Requires mod to properly function"
+	)
+	public boolean keepHealthOnEndExit = false;
+
 	@Config.Comment("The potion effects to apply on blights (Format: modid:potionname, amplifier)" + "\n" +
 			"Requires \"Additional Blight Potion Effects (ScalingHealth)\" enabled")
 	@Config.Name("Additional Blight Potion Effects List")

--- a/src/main/java/rlmixins/config/VanillaConfig.java
+++ b/src/main/java/rlmixins/config/VanillaConfig.java
@@ -19,6 +19,18 @@ public class VanillaConfig {
 	@MixinConfig.MixinToggle(earlyMixin = "mixins.rlmixins.early.vanilla.zombietrades.json", defaultValue = false)
 	public boolean zombieVillagersKeepTrades = false;
 
+	@Config.Comment("Fixes MC-6431: potion effects not carrying over when using the exit End Portal")
+	@Config.Name("Keep Potion Effects on End Exit")
+	@Config.RequiresMcRestart
+	@MixinConfig.MixinToggle(earlyMixin = "mixins.rlmixins.early.vanilla.endportaleffects.json", defaultValue = false)
+	public boolean keepEffectsOnEndExit = false;
+
+	@Config.Comment("Copies the player's attributes when using the Exit End Portal")
+	@Config.Name("Keep Attributes on End Exit")
+	@Config.RequiresMcRestart
+	@MixinConfig.MixinToggle(earlyMixin = "mixins.rlmixins.early.vanilla.endportalattributes.json", defaultValue = false)
+	public boolean keepAttributesOnEndExit = false;
+
 	@Config.Comment("Chance on curing zombie villagers to increase their prices and/or remove xp from some of their trades, per trade" + "\n" +
 			"Requires \"Cured Zombie Villagers Keep Trades (Vanilla)\" enabled")
 	@Config.Name("Curing Trauma Chance (Vanilla)")

--- a/src/main/java/rlmixins/handlers/ConfigHandler.java
+++ b/src/main/java/rlmixins/handlers/ConfigHandler.java
@@ -31,6 +31,9 @@ public class ConfigHandler {
 	
 	@Config.Name("EpicSiegeMod Config")
 	public static final EpicSiegeModConfig EPICSIEGEMOD_CONFIG = new EpicSiegeModConfig();
+
+	@Config.Name("FirstAid Config")
+	public static final FirstAidConfig FIRSTAID_CONFIG = new FirstAidConfig();
 	
 	@Config.Name("InFRLCraft Config")
 	public static final InFRLCraftConfig INFRLCRAFT_CONFIG = new InFRLCraftConfig();

--- a/src/main/java/rlmixins/handlers/firstaid/EndExitHandler.java
+++ b/src/main/java/rlmixins/handlers/firstaid/EndExitHandler.java
@@ -1,0 +1,32 @@
+package rlmixins.handlers.firstaid;
+
+import ichttt.mods.firstaid.FirstAid;
+import ichttt.mods.firstaid.api.CapabilityExtendedHealthSystem;
+import ichttt.mods.firstaid.api.damagesystem.AbstractPlayerDamageModel;
+import ichttt.mods.firstaid.common.network.MessageSyncDamageModel;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import java.util.Objects;
+
+/**
+ * Fix by XXMA16
+ */
+public class EndExitHandler {
+
+	@SubscribeEvent(priority = EventPriority.LOWEST)
+	public static void onPlayerClone(PlayerEvent.Clone event) {
+		if(event.isWasDeath()) {
+			return;
+		}
+		EntityPlayer player = event.getEntityPlayer();
+		if(!player.world.isRemote && player instanceof EntityPlayerMP) {
+			// damage model was already copied in the mixin, firing the event from there is too early
+			AbstractPlayerDamageModel cap = player.getCapability(CapabilityExtendedHealthSystem.INSTANCE, null);
+			FirstAid.NETWORKING.sendTo(new MessageSyncDamageModel(Objects.requireNonNull(cap), true), (EntityPlayerMP)player);
+		}
+	}
+}

--- a/src/main/java/rlmixins/handlers/potioncore/HealthFixHandler.java
+++ b/src/main/java/rlmixins/handlers/potioncore/HealthFixHandler.java
@@ -1,0 +1,21 @@
+package rlmixins.handlers.potioncore;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.event.entity.player.PlayerEvent;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+public class HealthFixHandler {
+
+	@SubscribeEvent(priority = EventPriority.LOWEST)
+	public static void onPlayerClone(PlayerEvent.Clone event) {
+		if(event.isWasDeath()) {
+			return;
+		}
+		NBTTagCompound old = event.getOriginal().getEntityData();
+		if(old.hasKey("Potion Core - Health Fix")) {
+			float oldHealth = old.getFloat("Potion Core - Health Fix");
+			event.getEntityPlayer().getEntityData().setFloat("Potion Core - Health Fix", oldHealth);
+		}
+	}
+}

--- a/src/main/java/rlmixins/mixin/firstaid/EventHandler_EndExitMixin.java
+++ b/src/main/java/rlmixins/mixin/firstaid/EventHandler_EndExitMixin.java
@@ -1,0 +1,37 @@
+package rlmixins.mixin.firstaid;
+
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import ichttt.mods.firstaid.api.damagesystem.AbstractDamageablePart;
+import ichttt.mods.firstaid.api.damagesystem.AbstractPlayerDamageModel;
+import ichttt.mods.firstaid.common.EventHandler;
+import net.minecraftforge.fml.common.gameevent.PlayerEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.function.Consumer;
+
+/**
+ * Fix by XXMA16
+ */
+@Mixin(EventHandler.class)
+public abstract class EventHandler_EndExitMixin {
+	@WrapOperation(
+			method = "onPlayerRespawn",
+			at = @At(value = "INVOKE", target = "Lnet/minecraftforge/fml/common/gameevent/PlayerEvent$PlayerRespawnEvent;isEndConquered()Z"),
+			remap = false
+	)
+	private static boolean rlmixins_firstAidModEventHandler_onPlayerRespawn(PlayerEvent.PlayerRespawnEvent instance, Operation<Boolean> original) {
+		return false;
+	}
+
+	@WrapWithCondition(
+			method = "onPlayerRespawn",
+			at = @At(value = "INVOKE", target = "Lichttt/mods/firstaid/api/damagesystem/AbstractPlayerDamageModel;forEach(Ljava/util/function/Consumer;)V"),
+			remap = false
+	)
+	private static boolean rlmixins_firstAidModEventHandler_onPlayerRespawn(AbstractPlayerDamageModel instance, Consumer<AbstractDamageablePart> consumer, PlayerEvent.PlayerRespawnEvent event) {
+		return !event.isEndConquered();
+	}
+}

--- a/src/main/java/rlmixins/mixin/firstaid/PlayerDamageModel_JoinDamageMixin.java
+++ b/src/main/java/rlmixins/mixin/firstaid/PlayerDamageModel_JoinDamageMixin.java
@@ -1,0 +1,53 @@
+package rlmixins.mixin.firstaid;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+import ichttt.mods.firstaid.api.damagesystem.AbstractDamageablePart;
+import ichttt.mods.firstaid.common.damagesystem.PlayerDamageModel;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Fix by XXMA16
+ */
+@Mixin(PlayerDamageModel.class)
+public abstract class PlayerDamageModel_JoinDamageMixin {
+
+	@Inject(
+			method = "runScaleLogic",
+			at = @At(
+					value = "INVOKE",
+					target = "Lichttt/mods/firstaid/common/damagesystem/PlayerDamageModel;iterator()Ljava/util/Iterator;",
+					ordinal = 0),
+			remap = false
+	)
+	private void rlmixins_firstAidModEventHandler_runScaleLogic_init(CallbackInfo ci, @Share("partsHp") LocalRef<Map<AbstractDamageablePart, Float>> hps) {
+		hps.set(new HashMap<>());
+	}
+
+	@Inject(method = "runScaleLogic",
+			at = @At(value = "INVOKE",
+					target = "Lichttt/mods/firstaid/api/damagesystem/AbstractDamageablePart;setMaxHealth(I)V",
+					ordinal = 0),
+			remap = false
+	)
+	private void rlmixins_firstAidModEventHandler_runScaleLogic_populate(CallbackInfo ci, @Local AbstractDamageablePart part, @Share("partsHp") LocalRef<Map<AbstractDamageablePart, Float>> hps) {
+		hps.get().put(part, part.currentHealth);
+	}
+
+	@Inject(method = "runScaleLogic",
+			at = @At(value = "INVOKE",
+					target = "Lnet/minecraft/profiler/Profiler;endSection()V",
+					ordinal = 0, remap = true),
+			remap = false
+	)
+	private void rlmixins_firstAidModEventHandler_runScaleLogic_restore(CallbackInfo ci, @Share("partsHp") LocalRef<Map<AbstractDamageablePart, Float>> hps) {
+		hps.get().forEach((part, hp) -> part.currentHealth = Math.min(hp, part.getMaxHealth()));
+	}
+}

--- a/src/main/java/rlmixins/mixin/firstaid/potioncore/PotionCoreEventHandler_EndExitMixin.java
+++ b/src/main/java/rlmixins/mixin/firstaid/potioncore/PotionCoreEventHandler_EndExitMixin.java
@@ -1,0 +1,37 @@
+package rlmixins.mixin.firstaid.potioncore;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.tmtravlr.potioncore.PotionCoreEventHandler;
+import ichttt.mods.firstaid.common.DataManagerWrapper;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayerMP;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+/**
+ * Fix by XXMA16
+ */
+@Mixin(PotionCoreEventHandler.class)
+public abstract class PotionCoreEventHandler_EndExitMixin {
+
+	@WrapOperation(
+			method = "updateEntityModifiers",
+			at = @At(
+					value = "INVOKE",
+					target = "Lnet/minecraft/entity/EntityLivingBase;setHealth(F)V",
+					ordinal = 0,
+					remap = true
+			),
+			remap = false
+	)
+	private static void rlmixins_firstAidModEventHandler_updateEntityModifiers(EntityLivingBase instance, float health, Operation<Void> original) {
+		if (!(instance instanceof EntityPlayerMP)) {
+			return;
+		}
+		DataManagerWrapper wrapper = (DataManagerWrapper) instance.getDataManager();
+		wrapper.toggleTracking(false);
+		original.call(instance, health);
+		wrapper.toggleTracking(true);
+	}
+}

--- a/src/main/java/rlmixins/mixin/firstaid/vanilla/EntityAttributeMapAccessor.java
+++ b/src/main/java/rlmixins/mixin/firstaid/vanilla/EntityAttributeMapAccessor.java
@@ -1,0 +1,13 @@
+package rlmixins.mixin.firstaid.vanilla;
+
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.ai.attributes.AbstractAttributeMap;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(EntityLivingBase.class)
+public interface EntityAttributeMapAccessor {
+
+	@Accessor("attributeMap")
+	void rlmixins$setAttributeMap(AbstractAttributeMap attributeMap);
+}

--- a/src/main/java/rlmixins/mixin/firstaid/vanilla/EntityPlayerMP_EndExitMixin.java
+++ b/src/main/java/rlmixins/mixin/firstaid/vanilla/EntityPlayerMP_EndExitMixin.java
@@ -1,0 +1,32 @@
+package rlmixins.mixin.firstaid.vanilla;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mojang.authlib.GameProfile;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.network.datasync.EntityDataManager;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import rlmixins.wrapper.FirstAidWrapper;
+
+/**
+ * Fix by XXMA16
+ */
+@Mixin(value = EntityPlayerMP.class, priority = 6000)
+public abstract class EntityPlayerMP_EndExitMixin extends EntityPlayer {
+
+	public EntityPlayerMP_EndExitMixin(World worldIn, GameProfile gameProfileIn) {
+		super(worldIn, gameProfileIn);
+	}
+
+	@WrapOperation(method = "copyFrom", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayerMP;setHealth(F)V"))
+	private void rlmixins_firstAidEntityPlayerMP_copyFrom(EntityPlayerMP instance, float hp, Operation<Void> original, EntityPlayerMP that, boolean keepEverything) {
+		EntityDataManager dataManager = instance.getDataManager();
+		FirstAidWrapper.toggleTracking(dataManager, false);
+		original.call(instance, hp);
+		FirstAidWrapper.copyPlayerDamageModel(that, instance);
+		FirstAidWrapper.toggleTracking(dataManager, true);
+	}
+}

--- a/src/main/java/rlmixins/mixin/scalinghealth/CommonEvents_EndHealthMixin.java
+++ b/src/main/java/rlmixins/mixin/scalinghealth/CommonEvents_EndHealthMixin.java
@@ -1,0 +1,27 @@
+package rlmixins.mixin.scalinghealth;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import net.minecraftforge.fml.common.gameevent.PlayerEvent;
+import net.silentchaos512.scalinghealth.event.ScalingHealthCommonEvents;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+/**
+ * Fix by XXMA16
+ */
+@Mixin(ScalingHealthCommonEvents.class)
+public abstract class CommonEvents_EndHealthMixin {
+	@ModifyExpressionValue(
+			method = "onPlayerRespawn",
+			at = @At(
+					value = "FIELD",
+					target = "Lnet/silentchaos512/scalinghealth/config/Config$Player$Health;allowModify:Z",
+					opcode = Opcodes.GETSTATIC
+			),
+			remap = false
+	)
+	private boolean rlmixins_scalingHealthCommonEvents_onPlayerRespawn(boolean original, PlayerEvent.PlayerRespawnEvent event) {
+		return original && !event.isEndConquered();
+	}
+}

--- a/src/main/java/rlmixins/mixin/vanilla/EntityPlayerMP_EndAttributesMixin.java
+++ b/src/main/java/rlmixins/mixin/vanilla/EntityPlayerMP_EndAttributesMixin.java
@@ -1,0 +1,31 @@
+package rlmixins.mixin.vanilla;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mojang.authlib.GameProfile;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import rlmixins.mixin.firstaid.vanilla.EntityAttributeMapAccessor;
+import rlmixins.mixin.firstaid.vanilla.EntityPlayerMP_EndExitMixin;
+
+/**
+ * Fix by XXMA16
+ * <p>
+ * This needs to wrap before {@link EntityPlayerMP_EndExitMixin}
+ */
+@Mixin(value = EntityPlayerMP.class, priority = 500)
+public abstract class EntityPlayerMP_EndAttributesMixin extends EntityPlayer {
+
+	public EntityPlayerMP_EndAttributesMixin(World worldIn, GameProfile gameProfileIn) {
+		super(worldIn, gameProfileIn);
+	}
+
+	@WrapOperation(method = "copyFrom", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayerMP;setHealth(F)V"))
+	private void rlmixins_firstAidEntityPlayerMP_copyFrom(EntityPlayerMP instance, float hp, Operation<Void> original, EntityPlayerMP that, boolean keepEverything) {
+		((EntityAttributeMapAccessor) this).rlmixins$setAttributeMap(that.getAttributeMap());
+		original.call(instance, hp);
+	}
+}

--- a/src/main/java/rlmixins/mixin/vanilla/EntityPlayerMP_EndEffectsMixin.java
+++ b/src/main/java/rlmixins/mixin/vanilla/EntityPlayerMP_EndEffectsMixin.java
@@ -1,0 +1,33 @@
+package rlmixins.mixin.vanilla;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.mojang.authlib.GameProfile;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+/**
+ * Fix by XXMA16
+ */
+@Mixin(value = EntityPlayerMP.class, priority = 500)
+public abstract class EntityPlayerMP_EndEffectsMixin extends EntityPlayer {
+
+	public EntityPlayerMP_EndEffectsMixin(World worldIn, GameProfile gameProfileIn) {
+		super(worldIn, gameProfileIn);
+	}
+
+	/**
+	 * Fixes MC-6431: potion effects not carrying over when using the exit End Portal
+	 */
+	@WrapOperation(
+			method = "copyFrom",
+			at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayerMP;setHealth(F)V")
+	)
+	private void rlmixins_vanillaEntityPlayerMP_copyFrom_inject(EntityPlayerMP instance, float hp, Operation<Void> original, EntityPlayerMP that, boolean keepEverything) {
+		getActivePotionMap().putAll(that.getActivePotionMap());
+		original.call(instance, hp);
+	}
+}

--- a/src/main/java/rlmixins/proxy/CommonProxy.java
+++ b/src/main/java/rlmixins/proxy/CommonProxy.java
@@ -5,7 +5,9 @@ import net.minecraft.item.Item;
 import net.minecraftforge.common.MinecraftForge;
 import rlmixins.handlers.ConfigHandler;
 import rlmixins.handlers.bettersurvival.PenetrationHandler;
+import rlmixins.handlers.firstaid.EndExitHandler;
 import rlmixins.handlers.potioncore.CureHandler;
+import rlmixins.handlers.potioncore.HealthFixHandler;
 import rlmixins.handlers.quark.PirateHatHandler;
 import rlmixins.handlers.rlartifacts.AntidoteHandler;
 import rlmixins.handlers.rlcombat.NetherBaneHandler;
@@ -28,8 +30,14 @@ public class CommonProxy {
                 ModLoadedUtil.isRLCombatLoaded()) {
             MinecraftForge.EVENT_BUS.register(PenetrationHandler.class);
         }
+        if(ConfigHandler.FIRSTAID_CONFIG.endExitHealthPatch && ModLoadedUtil.isFirstAidLoaded()) {
+            MinecraftForge.EVENT_BUS.register(EndExitHandler.class);
+        }
         if(ConfigHandler.POTIONCORE_CONFIG.cureAppliesOnAttack && ModLoadedUtil.isPotionCoreLoaded()) {
             MinecraftForge.EVENT_BUS.register(CureHandler.class);
+        }
+        if(ConfigHandler.POTIONCORE_CONFIG.persistentHealthFix && ModLoadedUtil.isPotionCoreLoaded()) {
+            MinecraftForge.EVENT_BUS.register(HealthFixHandler.class);
         }
         if(ConfigHandler.QUARK_CONFIG.pirateHatLooting && ModLoadedUtil.isQuarkLoaded()) {
             MinecraftForge.EVENT_BUS.register(PirateHatHandler.class);

--- a/src/main/java/rlmixins/util/ModLoadedUtil.java
+++ b/src/main/java/rlmixins/util/ModLoadedUtil.java
@@ -15,6 +15,7 @@ public abstract class ModLoadedUtil {
 	public static final String DefiledLands_MODID = "defiledlands";
 	public static final String DistinctDamageDescriptions_MODID = "distinctdamagedescriptions";
 	public static final String EpicSiegeMod_MODID = "epicsiegemod";
+	public static final String FirstAid_MOID = "firstaid";
 	public static final String InfernalMobs_MODID = "infernalmobs";
 	public static final String InFRLCraft_MODID = "iceandfire";
 	public static final String Inspirations_MODID = "inspirations";
@@ -37,6 +38,7 @@ public abstract class ModLoadedUtil {
 	private static Boolean charmLoaded = null;
 	private static Boolean chunkAnimatorLoaded = null;
 	private static Boolean dddLoaded = null;
+	private static Boolean firstAidLoaded = null;
 	private static Boolean potionCoreLoaded = null;
 	private static Boolean quarkLoaded = null;
 	private static Boolean rlArtifactsLoaded = null;
@@ -69,6 +71,11 @@ public abstract class ModLoadedUtil {
 	public static boolean isDDDLoaded() {
 		if(dddLoaded == null) dddLoaded = Loader.isModLoaded(DistinctDamageDescriptions_MODID);
 		return dddLoaded;
+	}
+
+	public static boolean isFirstAidLoaded() {
+		if(firstAidLoaded == null) firstAidLoaded = Loader.isModLoaded(FirstAid_MOID);
+		return firstAidLoaded;
 	}
 	
 	public static boolean isPotionCoreLoaded() {

--- a/src/main/java/rlmixins/wrapper/FirstAidWrapper.java
+++ b/src/main/java/rlmixins/wrapper/FirstAidWrapper.java
@@ -1,0 +1,22 @@
+package rlmixins.wrapper;
+
+import ichttt.mods.firstaid.api.CapabilityExtendedHealthSystem;
+import ichttt.mods.firstaid.api.damagesystem.AbstractPlayerDamageModel;
+import ichttt.mods.firstaid.common.DataManagerWrapper;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.network.datasync.EntityDataManager;
+
+import java.util.Objects;
+
+public class FirstAidWrapper {
+
+	public static void toggleTracking(EntityDataManager dataManager, boolean track) {
+		((DataManagerWrapper) dataManager).toggleTracking(track);
+	}
+
+	public static void copyPlayerDamageModel(EntityPlayerMP source, EntityPlayerMP target) {
+		AbstractPlayerDamageModel oldCap = source.getCapability(CapabilityExtendedHealthSystem.INSTANCE, null);
+		AbstractPlayerDamageModel newCap = target.getCapability(CapabilityExtendedHealthSystem.INSTANCE, null);
+		Objects.requireNonNull(newCap).deserializeNBT(Objects.requireNonNull(oldCap).serializeNBT());
+	}
+}

--- a/src/main/resources/mixins.rlmixins.early.firstaid.endexithealth.json
+++ b/src/main/resources/mixins.rlmixins.early.firstaid.endexithealth.json
@@ -1,0 +1,12 @@
+{
+  "required": true,
+  "package": "rlmixins.mixin",
+  "refmap": "mixins.rlmixins.refmap.json",
+  "compatibilityLevel": "JAVA_8",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "mixins": [
+    "firstaid.vanilla.EntityAttributeMapAccessor",
+    "firstaid.vanilla.EntityPlayerMP_EndExitMixin"
+  ]
+}

--- a/src/main/resources/mixins.rlmixins.early.vanilla.endportalattributes.json
+++ b/src/main/resources/mixins.rlmixins.early.vanilla.endportalattributes.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "package": "rlmixins.mixin",
+  "refmap": "mixins.rlmixins.refmap.json",
+  "compatibilityLevel": "JAVA_8",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "mixins": [
+    "vanilla.EntityPlayerMP_EndAttributesMixin"
+  ]
+}

--- a/src/main/resources/mixins.rlmixins.early.vanilla.endportaleffects.json
+++ b/src/main/resources/mixins.rlmixins.early.vanilla.endportaleffects.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "package": "rlmixins.mixin",
+  "refmap": "mixins.rlmixins.refmap.json",
+  "compatibilityLevel": "JAVA_8",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "mixins": [
+    "vanilla.EntityPlayerMP_EndEffectsMixin"
+  ]
+}

--- a/src/main/resources/mixins.rlmixins.late.firstaid.endexithealth.json
+++ b/src/main/resources/mixins.rlmixins.late.firstaid.endexithealth.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "package": "rlmixins.mixin",
+  "refmap": "mixins.rlmixins.refmap.json",
+  "compatibilityLevel": "JAVA_8",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "mixins": [
+    "firstaid.EventHandler_EndExitMixin"
+  ]
+}

--- a/src/main/resources/mixins.rlmixins.late.firstaid.login.json
+++ b/src/main/resources/mixins.rlmixins.late.firstaid.login.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "package": "rlmixins.mixin",
+  "refmap": "mixins.rlmixins.refmap.json",
+  "compatibilityLevel": "JAVA_8",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "mixins": [
+    "firstaid.PlayerDamageModel_JoinDamageMixin"
+  ]
+}

--- a/src/main/resources/mixins.rlmixins.late.firstaid.potioncore.endexithealth.json
+++ b/src/main/resources/mixins.rlmixins.late.firstaid.potioncore.endexithealth.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "package": "rlmixins.mixin",
+  "refmap": "mixins.rlmixins.refmap.json",
+  "compatibilityLevel": "JAVA_8",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "mixins": [
+    "firstaid.potioncore.PotionCoreEventHandler_EndExitMixin"
+  ]
+}

--- a/src/main/resources/mixins.rlmixins.late.scalinghealth.endexithealth.json
+++ b/src/main/resources/mixins.rlmixins.late.scalinghealth.endexithealth.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "package": "rlmixins.mixin",
+  "refmap": "mixins.rlmixins.refmap.json",
+  "compatibilityLevel": "JAVA_8",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "mixins": [
+    "scalinghealth.CommonEvents_EndHealthMixin"
+  ]
+}


### PR DESCRIPTION
Added fixes for the following issues (macro view):

- potion effects not being ported over when using the Exit End Portal
- body part health not being ported when using the Exit End Portal (FirstAid)
- losing some health when joining a world (FirstAid)

The actual issues stem from the very weird way Minecraft handles the End Exit and FirstAid, ScalingHaalth and PotionCore not accounting for this.

I have done some testing and it seems the player **won't** randomly die when exiting the end and doesn't get extra health.

Some issues still persist:

- body part health distribution is non-deterministic when using baubles with health boosting modifiers
- baubles with health modifiers still cause the player to lose some hp when returning from the End
- slight client desync when returning from the End (FirstAid health overlay, will sync up)